### PR TITLE
Fix typo

### DIFF
--- a/tei/seneca-medea.xml
+++ b/tei/seneca-medea.xml
@@ -1318,7 +1318,7 @@
           <milestone unit="line" ed="exclude" n="479"/>
           <l>per victa monstra, per manus, pro te quibus</l>
           <milestone unit="line" ed="exclude" n="480"/>
-          <l n="480">numquam peperci, perque prseteritos metus, </l>
+          <l n="480">numquam peperci, perque praeteritos metus, </l>
           <milestone unit="line" ed="exclude" n="481"/>
           <l>per caelum et undas, coniugi testes mei,</l>
           <milestone unit="line" ed="exclude" n="482"/>


### PR DESCRIPTION
In line 480 of _Medea_, replaces "prseteritos" with "praeteritos" 